### PR TITLE
Proper check for non-empty senderEmail value

### DIFF
--- a/Classes/PostProcess/MailPostProcessor.php
+++ b/Classes/PostProcess/MailPostProcessor.php
@@ -167,7 +167,7 @@ class MailPostProcessor extends AbstractPostProcessor implements PostProcessorIn
      */
     protected function setFrom()
     {
-        if (isset($this->typoScript['senderEmail'])) {
+        if (!empty($this->typoScript['senderEmail'])) {
             $fromEmail = $this->formUtility->renderItem(
                 $this->typoScript['senderEmail.'],
                 $this->typoScript['senderEmail']


### PR DESCRIPTION
Not providing a value for senderEmail in form configuration results in $fromEmail being set to empty string, bypassing senderEmailField and defaultMailFromAddress. Checking that the value is non-empty [!empty() rather than isset()] restores ability to use senderEmailField in form configuration to change the sender's email address.